### PR TITLE
Fix incorrect outlining

### DIFF
--- a/autoload/unite/sources/outline.vim
+++ b/autoload/unite/sources/outline.vim
@@ -1135,7 +1135,7 @@ function! s:skip_while(pattern, from)
 endfunction
 
 function! s:skip_until(pattern, from)
-  let lnum = a:from + 1 | let num_lines = line('$')
+  let lnum = a:from | let num_lines = line('$')
   while lnum <= num_lines
     let line = getline(lnum)
     let lnum += 1


### PR DESCRIPTION
In filetype `javascript`. Probably, filetype `cpp` would be the same.
### it's works fine.

``` javascript
var f = function() {};
f.prototype.something = function() {};
```

this output is

```
Sources: outline (1/1)
> 
- something()
```

and this is also no problem.

``` javascript


/**/
var f = function() {};
f.prototype.something = function() {};
```
### It's problem version.

``` javascript
/**/
var f = function() {};
f.prototype.something = function() {};
```

this output is

```
Sources: outline
> 
```
