### PR TITLE
Add C# support to unite-outline using ctags.

### DIFF
--- a/autoload/unite/sources/outline/defaults/cs.vim
+++ b/autoload/unite/sources/outline/defaults/cs.vim
@@ -1,0 +1,53 @@
+"=============================================================================
+" File    : autoload/unite/sources/outline/defaults/cs.vim
+" Author  : ssteinbach ssteinbach@github.com
+" Updated : 2014-02-08
+"
+" Licensed under the MIT license:
+" http://www.opensource.org/licenses/mit-license.php
+"
+"=============================================================================
+
+" Default outline info for C#
+" Version: 0.2.0
+
+function! unite#sources#outline#defaults#cs#outline_info()
+  return s:outline_info
+endfunction
+
+let s:Ctags = unite#sources#outline#import('Ctags')
+let s:Util  = unite#sources#outline#import('Util')
+
+"-----------------------------------------------------------------------------
+" Outline Info
+
+let s:outline_info = {
+      \ 'heading_groups': {
+      \   'namespace': ['namespace'],
+      \   'type'     : ['class', 'enum', 'struct', 'typedef'],
+      \   'function' : ['function', 'macro'],
+      \ },
+      \
+      \ 'not_match_patterns': [
+      \   s:Util.shared_pattern('*', 'parameter_list'),
+      \ ],
+      \
+      \ 'highlight_rules': [
+      \   { 'name'   : 'parameter_list',
+      \     'pattern': '/(.*)/' },
+      \   { 'name'   : 'type',
+      \     'pattern': '/\S\+\ze\%( #\d\+\)\= : \%(class\|enum\|struct\|typedef\)/' },
+      \   { 'name'   : 'function',
+      \     'pattern': '/\%(=> .*\)\@<!\(operator\>.*\|\h\w*\)\ze\s*(/' },
+      \   { 'name'   : 'macro',
+      \     'pattern': '/\h\w*\ze .*=> /' },
+      \   { 'name'   : 'expanded',
+      \     'pattern': '/ => \zs.*/' },
+      \   { 'name'   : 'id',
+      \     'pattern': '/ \zs#\d\+/' },
+      \ ],
+      \}
+
+function! s:outline_info.extract_headings(context)
+  return s:Ctags.extract_headings(a:context)
+endfunction

--- a/autoload/unite/sources/outline/modules/ctags.vim
+++ b/autoload/unite/sources/outline/modules/ctags.vim
@@ -120,7 +120,7 @@ function! s:execute_ctags(context)
   " Assemble the command-line.
   let lang_info = s:Ctags.lang_info[filetype]
   let opts  = ' -f - --excmd=number --fields=afiKmsSzt --sort=no --append=no'
-  let opts .= ' --language-force=' . lang_info.name . ' '
+  let opts .= " --language-force='" . lang_info.name . "' "
   let opts .= lang_info.ctags_options
 
   let path = s:Util.Path.normalize(temp_file)
@@ -436,6 +436,13 @@ call extend(s:Ctags.lang_info.c, {
       \ 'name': 'C',
       \ 'ctags_options': ' --c-kinds=cdfgnstu '
       \ }, 'force')
+
+let s:Ctags.lang_info.cs = {
+      \ 'name': 'C#',
+      \ 'ctags_options': " '--C#-kinds=cdgnsmt' ",
+      \ 'scope_kinds'  : ['namespace', 'class', 'enum'],
+      \ 'scope_delim'  : '.',
+      \ }
 
 "-----------------------------------------------------------------------------
 " Java


### PR DESCRIPTION
- In the code, refer to C# as "cs" consistent with the vim-filetype.
- Because of the # character in C#, quote the arguments to ctags where
  the # character appears -in forcing the language and setting kinds.
- Add the lang_info.cs entry so that ctags is used for cs.
- Copied the outline_info struct from C++.
