### PR TITLE
Add a section to the markdown on extending unite-outline.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -41,6 +41,24 @@ corresponding location of the buffer.
 
 See :help unite-outline for more details.
 
+## Extending
+
+The easiest way to extend this plugin is if your language is supported by 
+ctags.  If this is the case, add an entry to the lang_info dictionary in:
+
+    ./autoload/unite/sources/outline/modules/ctags.vim
+
+The --ctags-options field in the dictionary gets passed to ctags and specifies
+the things ctags will report, the other fields control how unite-outline 
+organizines the items that ctags returns.
+
+Finally, add an outline_info dictionary in a file named after your filetype:
+
+    ./autoload/unite/sources/outline/defaults/{FILETYPE}.vim
+
+See the other filetypes already in autoload/unite/sources/outline/defaults
+for examples of what those files look like.  Good luck!
+
 ## Screenshots
 
 See [unite-outline's wiki](https://github.com/h1mesuke/unite-outline/wiki).


### PR DESCRIPTION
Your comment was correct - this is a tough plugin to extend.  I went back in and added some notes to the markdown to help people in the future extend it. Let me know if you think this is handy to merge in/ if it could use any other notes!
