### PR TITLE
Outline not working for Java/C/C++ files #24

### DIFF
--- a/autoload/unite/sources/outline/modules/ctags.vim
+++ b/autoload/unite/sources/outline/modules/ctags.vim
@@ -62,8 +62,8 @@ function! s:find_exuberant_ctags()
         \ 'ctags',
         \ 'tags',
         \ ]
-  if exists('g:neocomplcache_ctags_program') && !empty(g:neocomplcache_ctags_program)
-    let ctags_exe_names = [g:neocomplcache_ctags_program] + ctags_exe_names
+  if exists('g:unite_source_outline_ctags_program') && !empty(g:neocomplcache_ctags_program)
+    let ctags_exe_names = [g:unite_source_outline_ctags_program] + ctags_exe_names
   endif
   for ctags in ctags_exe_names
     if executable(ctags)

--- a/doc/unite-outline.txt
+++ b/doc/unite-outline.txt
@@ -256,6 +256,18 @@ VARIABLES				*unite-outline-variables*
 
 		See |unite-outline-info-highlight_rules|.
 
+					*g:unite_source_outline_ctags_program*
+	g:unite_source_outline_ctags_program
+
+		String pointing to the absolute path of the ctags executable.
+
+		Default value is ''
+
+		Example: >
+		let g:unite_source_outline_ctags_program =
+		      \ '/usr/local/bin/ctags'
+<
+
 ------------------------------------------------------------------------------
 SETTINGS EXAMPLE			*unite-outline-settings-example*
 >


### PR DESCRIPTION
[Problem]
In some cases (read Mac OS with Xcode installed) when executing ctags from
inside vim you end up executing the binary distributed by apple which doesn't
support long options (arguments started with double -, e.g. --version) and this
causes unite-outline to fail to recognize ctags.

[Solution]
Create a global variable setting to allow user to specify the correct ctags path
and use it.

[Note]
Previously unite-outline was already using a global variable for that mater but
it inherit from neocomplcache. I simply rename it to be consistent with all
other variables and add documentation about it.
