### PR TITLE
Fix ctags check for different global vars.

### DIFF
--- a/autoload/unite/sources/outline/modules/ctags.vim
+++ b/autoload/unite/sources/outline/modules/ctags.vim
@@ -62,7 +62,7 @@ function! s:find_exuberant_ctags()
         \ 'ctags',
         \ 'tags',
         \ ]
-  if exists('g:unite_source_outline_ctags_program') && !empty(g:neocomplcache_ctags_program)
+  if exists('g:unite_source_outline_ctags_program') && !empty(g:unite_source_outline_ctags_program)
     let ctags_exe_names = [g:unite_source_outline_ctags_program] + ctags_exe_names
   endif
   for ctags in ctags_exe_names


### PR DESCRIPTION
[Problem]
Before submitting my last change I forgot to rebase my branch with the mainline
and this caused the ctags check to check if one variable existed and if other
totally non related one was not empty.

[Solution]
In the ctags check use the same global variable so the test can actually pass.
