### PR TITLE
Subsubsections get numbered in articles

### DIFF
--- a/autoload/unite/sources/outline/defaults/tex.vim
+++ b/autoload/unite/sources/outline/defaults/tex.vim
@@ -128,7 +128,7 @@ function! s:unit_seqnr_prefix(unit)
       let seqnr = [s:unit_count.section, s:unit_count.subsection]
     endif
   elseif a:unit ==# 'subsubsection'
-    if s:unit_count.chapter > 0
+    if s:unit_count.chapter == 0
       let seqnr = [s:unit_count.section, s:unit_count.subsection, s:unit_count.subsubsection]
     endif
   endif


### PR DESCRIPTION
Suppose that there are two LaTeX files `article.tex` and `report.tex`:

```
\documentclass{article}
\begin{document}
  \section{New Section}
  \subsection{New Subsection}
  \subsubsection{New Subsubsection}
\end{document}
```

```
\documentclass{report}
\begin{document}
  \chapter{New Chapter}
  \section{New Section}
  \subsection{New Subsection}
  \subsubsection{New Subsubsection}
\end{document}
```

Currently, `Unite outline` generates outlines for these two files as

```
  1 New Section
    1.1 New Subsection
      New Subsubsection
```

```
  1 New Chapter
    1.1 New Section
      1.1.1 New Subsection
        1.1.1 New Subsubsection
```

respectively. As you can see, in `article.tex` subsubsections don't get numbered, by contrast in `report.tex` subsubsections do get numbered in a weird way (not as 1.1.1.1). This patch changes the outlines as

```
  1 New Section
    1.1 New Subsection
      1.1.1 New Subsubsection
```

```
  1 New Chapter
    1.1 New Section
      1.1.1 New Subsection
        New Subsubsection
```

which resembles the default behaviour of LaTeX and makes more sense.
