### PR TITLE
Initial typescript support via ctags

### DIFF
--- a/autoload/unite/sources/outline/defaults/typescript.vim
+++ b/autoload/unite/sources/outline/defaults/typescript.vim
@@ -1,0 +1,42 @@
+"=============================================================================
+" File    : autoload/unite/sources/outline/defaults/typescript.vim
+" Author  : prabirshrestha <mail@prabir.me>
+" Updated : 2015-02-15
+"
+" Licensed under the MIT license:
+" http://www.opensource.org/licenses/mit-license.php
+"
+"=============================================================================
+
+" Default outline info for Typescript
+" Version: 0.0.1
+
+" Download typescript ctags at https://github.com/jb55/typescript-ctags
+
+function! unite#sources#outline#defaults#typescript#outline_info()
+  return s:outline_info
+endfunction
+
+let s:Ctags = unite#sources#outline#import('Ctags')
+let s:Util  = unite#sources#outline#import('Util')
+
+"-----------------------------------------------------------------------------
+" Outline Info
+
+let s:outline_info = {
+      \ 'heading_groups': {
+      \   'type'   : ['modules', 'classes', 'enums', 'interfaces'],
+      \   'method' : ['functions', 'varlambdas'],
+      \ },
+      \
+      \ 'highlight_rules': [
+      \   { 'name'   : 'type',
+      \     'pattern': '/\S\+\ze : \%(module\|interface\|class\|enum\)/' },
+      \   { 'name'   : 'method',
+      \     'pattern': '/\h\w*\ze\s*(/' },
+      \ ],
+      \}
+
+function! s:outline_info.extract_headings(context)
+  return s:Ctags.extract_headings(a:context)
+endfunction

--- a/autoload/unite/sources/outline/modules/ctags.vim
+++ b/autoload/unite/sources/outline/modules/ctags.vim
@@ -449,6 +449,12 @@ let s:Ctags.lang_info.cs = {
       \ 'scope_delim'  : '.',
       \ }
 
+let s:Ctags.lang_info.typescript = {
+      \ 'name': 'typescript',
+      \ 'ctags_options': '',
+      \ 'scope_kinds'  : ['modules', 'classes', 'interfaces', 'enums', 'functions', 'varlambdas'],
+      \ }
+
 "-----------------------------------------------------------------------------
 " Java
 "


### PR DESCRIPTION
Since ctags doesn't support tyescript by default there is a manual process for adding the ctags file https://github.com/jb55/typescript-ctags.

![image](https://cloud.githubusercontent.com/assets/287744/6204432/ce6539ca-b4ff-11e4-9302-1e65d2a58360.png)