### PR TITLE
Windows support

### DIFF
--- a/autoload/unite/sources/outline/modules/ctags.vim
+++ b/autoload/unite/sources/outline/modules/ctags.vim
@@ -125,17 +125,20 @@ function! s:execute_ctags(context)
   " Assemble the command-line.
   let lang_info = s:Ctags.lang_info[filetype]
   let opts  = ' -f - --excmd=number --fields=afiKmsSzt --sort=no --append=no'
-  let opts .= " --language-force='" . lang_info.name . "' "
+  let opts .= " --language-force=\"" . lang_info.name . "\" "
   let opts .= lang_info.ctags_options
 
   let path = s:Util.Path.normalize(temp_file)
   let path = s:Util.String.shellescape(path)
 
   let cmdline = s:Ctags.exe . opts . path
+  echom cmdline
 
   " Execute the Ctags.
   let ctags_out = unite#util#system(cmdline)
+  echom ctags_out
   let status = unite#util#get_last_status()
+  echom status
   if status != 0
     call unite#print_message(
           \ "[unite-outline] ctags failed with status " . status . ".")

--- a/autoload/unite/sources/outline/modules/ctags.vim
+++ b/autoload/unite/sources/outline/modules/ctags.vim
@@ -132,13 +132,10 @@ function! s:execute_ctags(context)
   let path = s:Util.String.shellescape(path)
 
   let cmdline = s:Ctags.exe . opts . path
-  echom cmdline
 
   " Execute the Ctags.
   let ctags_out = unite#util#system(cmdline)
-  echom ctags_out
   let status = unite#util#get_last_status()
-  echom status
   if status != 0
     call unite#print_message(
           \ "[unite-outline] ctags failed with status " . status . ".")

--- a/autoload/unite/sources/outline/modules/util.vim
+++ b/autoload/unite/sources/outline/modules/util.vim
@@ -280,7 +280,7 @@ endfunction
 call s:String.function('nr2roman')
 
 function! s:String_shellescape(str)
-  if &shell =~? '^\%(cmd\%(\.exe\)\=\|command\.com\)\%(\s\|$\)'
+  if &shell =~? '^\%(cmd\%(\.exe\)\=\|command\.com\)\%(\s\|$\)' || has('win32')
     return '"' . substitute(a:str, '"', '""', 'g') . '"'
   else
     return "'" . substitute(a:str, "'", "'\\\\''", 'g') . "'"

--- a/autoload/unite/sources/outline/modules/util.vim
+++ b/autoload/unite/sources/outline/modules/util.vim
@@ -280,7 +280,7 @@ endfunction
 call s:String.function('nr2roman')
 
 function! s:String_shellescape(str)
-  if &shell =~? '^\%(cmd\%(\.exe\)\=\|command\.com\)\%(\s\|$\)' || has('win32')
+  if &shell =~? '^\%(cmd\%(\.exe\)\=\|command\.com\)\%(\s\|$\)' || unite#util#is_windows()
     return '"' . substitute(a:str, '"', '""', 'g') . '"'
   else
     return "'" . substitute(a:str, "'", "'\\\\''", 'g') . "'"


### PR DESCRIPTION
On windows, unite-outline were not able to execute ctags due do shell escaping.

I have also tested this solution on a Mac OSX, and it worked fine.