### PR TITLE
Support 'pandoc' filetype for markdown files.

### DIFF
--- a/autoload/unite/sources/outline.vim
+++ b/autoload/unite/sources/outline.vim
@@ -40,7 +40,7 @@ let s:OUTLINE_INFO_PATH = [
 
 " NOTE: source <- [aliases...]
 let s:OUTLINE_ALIASES = {
-      \ 'markdown': ['mkd'],
+      \ 'markdown': ['mkd', 'pandoc'],
       \ 'cpp'     : ['c'],
       \ 'dosini'  : ['cfg'],
       \ 'tex'     : ['plaintex'],


### PR DESCRIPTION
vim-pandoc is a popular filetype plugin for pandoc's extended markdown format. The underlying specification is still markdown, though, so we can use markdown outline detection for the 'pandoc' filetype.