### PR TITLE
javascript: Fix broken function and exported class outlines

### DIFF
--- a/autoload/unite/sources/outline/defaults/javascript.vim
+++ b/autoload/unite/sources/outline/defaults/javascript.vim
@@ -146,12 +146,13 @@ function! s:outline_info.create_heading(which, heading_line, matched_line, conte
       else
         let heading.level = 2
         let matched_list = matchlist(a:heading_line, s:pat_es6_method)
-        " Not match key words
-        if empty(matched_list) || match(a:heading_line, '^\s*\(for\|if\|while\|switch\)') != -1
-          let heading.level = 0
-        else
-          let [func_name, arg_list] = matched_list[1:2]
-          let heading.word = func_name . '(' . arg_list . ')'
+        if len(matched_list) > 0
+          if match(a:heading_line, '^\s*\%(for\|if\|while\|switch\)\>') != -1
+            let heading.level = 0
+          else
+            let [func_name, arg_list] = matched_list[1:2]
+            let heading.word = func_name . '(' . arg_list . ')'
+          endif
         endif
       endif
     endif

--- a/autoload/unite/sources/outline/defaults/javascript.vim
+++ b/autoload/unite/sources/outline/defaults/javascript.vim
@@ -37,7 +37,7 @@ let s:pat_rvalue = '\(function\s*(\([^)]*\))\|(\(.*\))\s*{\|\s*{\|\(\w\+\)\s*(\(
 
 let s:pat_def =  '\%(\%(export\s\+\%(default\s\+\)\=\)\=function\>\)'
 
-let s:pat_es6_class = '^\s*class\s\+\(\S\+\).*{$'
+let s:pat_es6_class = '^\s*\%(export\s\+\%(default\s\+\)\=\)\=class\s\+\(\S\+\)\s*{$'
 " NOTE: This sub pattern contains 1 capture;  1:className
 
 let s:pat_es6_method = '^\s*\(\%(static\s\+\)\?\w\+\)\s*(\([^)]*\))\s*{$'
@@ -49,7 +49,9 @@ let s:pat_es6_method = '^\s*\(\%(static\s\+\)\?\w\+\)\s*(\([^)]*\))\s*{$'
 let s:outline_info = {
       \ 'heading-1': s:Util.shared_pattern('cpp', 'heading-1'),
       \ 'heading'  : '^\s*\%(' . s:pat_def . '\|' .
-      \   '\%(' . 'class\s\+\(\S\+\)\s\+\%(extends\s\+\w\+\)\?\|\s*\%(static\s\+\)\?\w\+\s*\|' . s:pat_assign . '\|' . s:pat_label . '\)\s*' . s:pat_rvalue . '\)',
+      \   '\%(' .
+      \     '\%(export\s\+\%(default\s\+\)\=\)\=class\s\+\(\S\+\)\s\+\%(extends\s\+\w\+\)\?\|\s*\%(static\s\+\)\?\w\+\s*\|' . s:pat_assign . '\|' . s:pat_label .
+      \   '\)\s*' . s:pat_rvalue . '\)',
       \
       \ 'skip': {
       \   'header': s:Util.shared_pattern('cpp', 'header'),


### PR DESCRIPTION
定義した関数と export されたクラスがアウトラインに出てこなかったので修正しました．

- Code

```javascript
function foo() {
}

export class Foo {
}

export default class Bar {
}
```

- Expected

```
foo()
class Foo
class Bar
```

- Actual

```

```

(No outline)