### PR TITLE
Fix an issue occurs when being shiftwidth=0

### DIFF
--- a/autoload/unite/sources/outline.vim
+++ b/autoload/unite/sources/outline.vim
@@ -682,6 +682,9 @@ function! s:create_context(bufnr, ...) abort
         \ 'sw'  : getbufvar(a:bufnr, '&shiftwidth'),
         \ 'ts'  : getbufvar(a:bufnr, '&tabstop'),
         \ }
+  if buffer.sw == 0
+    let buffer.sw = buffer.ts
+  endif
   let buffer.filetypes = split(getbufvar(a:bufnr, '&filetype'), '\.')
   let buffer.filetype = get(buffer.filetypes, 0, '')
   let context = {


### PR DESCRIPTION
As you know, Vim uses `'tabstop'` as `'shiftwidth'` when `shiftwidth=0`.