### PR TITLE
python: Recognize async methods

### DIFF
--- a/autoload/unite/sources/outline/defaults/python.vim
+++ b/autoload/unite/sources/outline/defaults/python.vim
@@ -21,7 +21,7 @@ let s:Util = unite#sources#outline#import('Util')
 " Outline Info
 
 let s:outline_info = {
-      \ 'heading'  : '^\s*\%(class\|def\)\>',
+      \ 'heading'  : '^\s*\%(class\|\%(async\s\+\)\=def\)\>',
       \
       \ 'skip': {
       \   'header': s:Util.shared_pattern('sh', 'header'),
@@ -60,10 +60,10 @@ function! s:outline_info.create_heading(which, heading_line, matched_line, conte
     " Class
     let heading.type = 'class'
     let heading.word = matchstr(heading.word, '^\s*class\s\+\zs\h\w*') . ' : class'
-  elseif heading.word =~ '^\s*def\>'
+  elseif heading.word =~ '^\s*\%(async\s\+\)\=def\>'
     " Function
     let heading.type = 'function'
-    let heading.word = substitute(heading.word, '\<def\s*', '', '')
+    let heading.word = substitute(heading.word, '\<\%(async\s\+\)\=def\s*', '', '')
     let heading.word = substitute(heading.word, '\S\zs(', ' (', '')
     let heading.word = substitute(heading.word, '\%(:\|#\).*$', '', '')
   endif


### PR DESCRIPTION
最近の Python は `async`/`await` キーワードで非同期な処理を記述できますが，非同期な処理を記述するメソッド `async def` を unite-outline がメソッドだと認識できないことに気づいたので修正ししました