### PR TITLE
Fix script local function is not found by removing SID hack

### DIFF
--- a/autoload/unite/sources/outline/modules/base.vim
+++ b/autoload/unite/sources/outline/modules/base.vim
@@ -39,18 +39,12 @@ endfunction
 
 "-----------------------------------------------------------------------------
 
-function! s:get_SID() abort
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
-endfunction
-let s:SID = s:get_SID()
-delfunction s:get_SID
-
 let s:Module = {}
 
 function! s:Module_bind(func_name) dict
   let self[a:func_name] = function(self.__prefix__  . a:func_name)
 endfunction
-let s:Module.__bind__ = function(s:SID . 'Module_bind')
+let s:Module.__bind__ = function('s:Module_bind')
 let s:Module.function = s:Module.__bind__ | " syntax sugar
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Running `:Unite outline` caused the following error:

```
[unite.vim] function neobundle#autoload#_command[14]..unite#helper#call_unite[33]..unite#start[1]..unite#start#standard[50]..unite#candidates#_recache[74]..<SN
R>158_recache_candidates_loop[42]..<SNR>158_get_source_candidates[40]..37[1]..unite#get_all_sources[1]..unite#variables#all_sources[2]..unite#init#_sources[11]
..unite#init#_default_scripts[54]..script /Users/rhysd/.vim/bundle/unite-outline/autoload/unite/sources/outline.vim[506]..function unite#sources#outline#import
[2]..script /Users/rhysd/.vim/bundle/unite-outline/autoload/unite/sources/outline/modules/file_cache.vim[39]..function unite#sources#outline#import[2]..script
/Users/rhysd/.vim/bundle/unite-outline/autoload/unite/sources/outline/modules/util.vim[44]../Users/rhysd/.vim/bundle/unite-outline/autoload/unite/sources/outli
ne/modules/base.vim, line 53
[unite.vim] Vim(let):E700: Unknown function: <SNR>158_Module_bind
[unite.vim] Error occurred in source initialization!
[unite.vim] Source name is /Users/rhysd/.vim/bundle/unite-outline/autoload/unite/sources/outline.vim
```

Since `function()` can now take `s:` prefix for function name as first argument, the `s:SID` hack is no longer necessary. This PR removes the hack and I confirmed the error was fixed by the modification.