### PR TITLE
Fix an unknown issue with Ctags module and Module_bind function

### DIFF
--- a/autoload/unite/sources/outline/modules/ctags.vim
+++ b/autoload/unite/sources/outline/modules/ctags.vim
@@ -93,7 +93,7 @@ let s:Ctags.lang_info = {}
 function! s:Ctags_exists() abort
   return !empty(s:Ctags.exe)
 endfunction
-call s:Ctags.function('exists')
+let s:Ctags.exists = function('s:Ctags_exists')
 
 " Returns True if the Exuberant Ctags supports {filetype}.
 "
@@ -106,7 +106,7 @@ function! s:Ctags_supports(filetype) abort
     return index(split(ctags_out, "\<NL>"), lang_info.name, 1) >= 0
   endif
 endfunction
-call s:Ctags.function('supports')
+let s:Ctags.supports = function('s:Ctags_supports')
 
 " Executes the Ctags and returns a List of tag objects.
 "
@@ -288,7 +288,7 @@ function! s:Ctags_extract_headings(context) abort
   endif
   return root
 endfunction
-call s:Ctags.function('extract_headings')
+let s:Ctags.extract_headings = function('s:Ctags_extract_headings')
 
 " Creates a heading from {tag}.
 "


### PR DESCRIPTION
Hello,

Since several days, I have an issue with unite-outline.
The symptom is that it stop working for C/C++ file types, while still working for Python.

Today, I took time to debug this issue and found that, for the ctags module only, the function Module_bind did not work anymore (It does something like a silent error at call s:Ctags.function('exists'), the remaining part of the ctags.vim script is not executed).
When I replaced this function call by directly affecting the ctags.<function> variables, the issue was fixed.

I am not a vim scripter, but if someone else has this issue, well, here is a solution that worked for me.
I think that the whole SID thing could be removed, improving readability and maintainability of the code.